### PR TITLE
fix(timer): 터치 스와이프 preventDefault 경고 및 hooks deps 경고 해결 (TORY-65)

### DIFF
--- a/src/features/_common/components/Timer/TimerModal/SwipeTimerInput.css
+++ b/src/features/_common/components/Timer/TimerModal/SwipeTimerInput.css
@@ -26,6 +26,9 @@
   transition: all 0.2s ease;
   border: 2px solid transparent;
   position: relative;
+  /* 터치 스크롤 제스처를 비활성화해 드래그 동작에 집중 */
+  touch-action: none;
+  overscroll-behavior: contain;
 }
 
 .swipe-timer-container:hover {


### PR DESCRIPTION
- SwipeTimerInput: touchstart에서 preventDefault 제거, touchmove는 cancelable일 때만 호출
- CSS: .swipe-timer-container에 touch-action: none, overscroll-behavior: contain 추가
- 이벤트 핸들러 useCallback 적용 및 useEffect 의존성 보완
- ESLint react-hooks/exhaustive-deps 경고 및 콘솔 [Intervention] 경고 제거