### PR TITLE
Feature/tory 153 webview improve token refresh logic

### DIFF
--- a/src/_common/components/Error/Error.css
+++ b/src/_common/components/Error/Error.css
@@ -10,30 +10,26 @@
 
 .error-container h2 {
   font-size: 20px;
-  color: #ff4444;
+  color: var(--brand);
   margin-bottom: 12px;
 }
 
 .error-container p {
   font-size: 16px;
-  color: #666;
+  color: var(--text);
   margin-bottom: 24px;
   line-height: 1.5;
 }
 
 .error-container button {
   padding: 12px 24px;
-  background-color: #ff4444;
+  background-color: var(--muted);
   color: white;
   border: none;
   border-radius: 6px;
   font-size: 16px;
   cursor: pointer;
   transition: background-color 0.2s ease;
-}
-
-.error-container button:hover {
-  background-color: #e63939;
 }
 
 /* 에러 액션 버튼들을 가로로 배치 */

--- a/src/index.css
+++ b/src/index.css
@@ -9,7 +9,7 @@
   --line-strong: rgba(249, 115, 22, 0.15);
   --brand: #ff4500;
   --brand-dark: #e03d00;
-  --brand-light: #fed7aa;
+  --brand-light: #fff5f0;
 
   /* 모바일 최적화 간격 */
   --space-sm: 8px;
@@ -73,5 +73,5 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background-color: #f5f5f5;
+  background-color: white;
 }

--- a/src/recipe/detail/RecipeDetailPage.tsx
+++ b/src/recipe/detail/RecipeDetailPage.tsx
@@ -11,7 +11,7 @@ const RecipeDetailPage = (): JSX.Element => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
 
-  const { recipeData, loading, error } = useRecipeData(id);
+  const { recipeData, isLoading, errorMessage: errorMessage } = useRecipeData(id);
 
   // 화면 전환 애니메이션
   const { transitioning, fadeIn } = useTransition();
@@ -25,16 +25,14 @@ const RecipeDetailPage = (): JSX.Element => {
   const bridgeActions = useBridgeActions(recipeData);
 
   // 로딩 중에는 스크롤 잠금
-  useBodyScrollLock(loading);
+  useBodyScrollLock(isLoading);
 
   return (
     <div className={`app ${transitioning ? 'transitioning' : ''} ${fadeIn ? 'fade-in' : ''}`}>
-      {loading ? (
+      {isLoading ? (
         <Loading />
-      ) : error ? (
-        <Error error={error} />
-      ) : !recipeData ? (
-        <Error error="레시피 데이터를 찾을 수 없습니다." />
+      ) : !recipeData || errorMessage ? (
+        <Error error={errorMessage || '레시피를 찾을 수 없습니다.'} />
       ) : (
         <RecipeInfo
           recipeData={recipeData}

--- a/src/recipe/detail/api/fetchRecipe.ts
+++ b/src/recipe/detail/api/fetchRecipe.ts
@@ -9,11 +9,6 @@ export const fetchRecipe = async (id: string, accessToken: string): Promise<Reci
     },
   });
 
-  // HTTP 응답 상태 체크 추가
-  if (!response.ok) {
-    throw new Error(`HTTP error! status: ${response.status}`);
-  }
-
   const apiResponse: RecipeData = await response.json();
 
   return apiResponse;


### PR DESCRIPTION
[TORY-153 feat(useRecipeData): 토큰 재발급 대기(3초) 추가 및 오류 처리/반환값 개선](https://github.com/SWMChefTory/frontend-recipe-webview/commit/b84997e8240bb716c2a689d510f862219d42ca10) 

- AUTH_001 또는 유효하지 않은 토큰 시 재발급 요청 전송 후 3초간 로딩 유지, 미완료 시 에러 표시
- 재발급 대기 상태에서 불필요한 로딩 상태 업데이트 방지
- 타임아웃 등록/해제(클린업) 추가
- 에러 메시지 문구 개선: 레시피 ID 없음, 인증 만료, 일반 오류 메시지 정제

[TORY-153 style: 에러 컴포넌트 css에서 색을 변수값으로 변경](https://github.com/SWMChefTory/frontend-recipe-webview/commit/65ed476f35282f0cf3a9311c110013df912eed0e)