### PR TITLE
TORY-208 feat: 계량법 페이지 라우팅 추가 및 네이티브 BACK_PRESSED 처리

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import '_common/styles/global.css';
 import { AccessTokenProvider } from 'bridge';
 import { Route, HashRouter as Router, Routes } from 'react-router-dom';
 import RecipeDetailPage from 'recipe/detail/RecipeDetailPage';
+import MeasurementPage from 'recipe/measurement/MeasurementPage';
 import RecipeStepPage from 'recipe/step/RecipeStepPage';
 import 'slick-carousel/slick/slick-theme.css';
 import 'slick-carousel/slick/slick.css';
@@ -11,6 +12,7 @@ const App = (): React.ReactNode => (
     <Router>
       <Routes>
         <Route path="/recipes/:id" element={<RecipeDetailPage />} />
+        <Route path="/recipes/:id/measurement" element={<MeasurementPage />} />
         <Route path="/recipes/:id/steps" element={<RecipeStepPage />} />
       </Routes>
     </Router>

--- a/src/_common/components/Error/Error.tsx
+++ b/src/_common/components/Error/Error.tsx
@@ -1,6 +1,6 @@
 import '_common/components/Error/Error.css';
 import { ErrorProps } from '_common/types';
-import { sendBackPressed } from 'bridge/utils/webview';
+import { sendGoHome } from 'bridge/utils/webview';
 import React from 'react';
 
 /**
@@ -9,8 +9,8 @@ import React from 'react';
  * @returns JSX 엘리먼트
  */
 const Error: React.FC<ErrorProps> = ({ error }) => {
-  const handleBack = (): void => {
-    sendBackPressed();
+  const handleGoHome = (): void => {
+    sendGoHome();
   };
 
   return (
@@ -18,7 +18,7 @@ const Error: React.FC<ErrorProps> = ({ error }) => {
       <h2>오류가 발생했습니다</h2>
       <p>{error}</p>
       <div className="error-actions" role="group" aria-label="에러 액션">
-        <button onClick={handleBack} type="button" aria-label="뒤로">
+        <button onClick={handleGoHome} type="button" aria-label="뒤로">
           뒤로
         </button>
       </div>

--- a/src/_common/constants/index.ts
+++ b/src/_common/constants/index.ts
@@ -1,17 +1,8 @@
 import { BridgeMessageType } from '../../bridge/types/webview';
 
-// 애플리케이션 전체에서 사용되는 상수들
-export const TRANSITION_DURATION = 150;
-export const LOADING_SIMULATION_DELAY = 500;
-
-export const DEFAULT_RECIPE_ID = '1';
-
 // React Native WebView 메시지 타입
 export const WEBVIEW_MESSAGE_TYPES: Record<string, BridgeMessageType> = {
-  START_COOKING: 'START_COOKING',
-  FINISH_COOKING: 'FINISH_COOKING',
-  BACK_TO_RECIPE: 'BACK_TO_RECIPE',
-  BACK_PRESSED: 'BACK_PRESSED',
+  GO_HOME: 'GO_HOME',
   REFRESH_TOKEN: 'REFRESH_TOKEN',
   TIMER_START: 'TIMER_START',
   TIMER_STOP: 'TIMER_STOP',

--- a/src/bridge/hooks/useWebViewActions.ts
+++ b/src/bridge/hooks/useWebViewActions.ts
@@ -3,10 +3,7 @@ import { RecipeData } from '../../recipe/detail/types/recipe';
 import { sendBridgeMessage } from '../utils/webview';
 
 interface UseWebViewActionsResult {
-  handleStartCooking: () => void;
-  handleFinishCooking: () => void;
-  handleBackToRecipe: () => void;
-  handleBack: () => void;
+  handleGoHome: () => void;
 }
 
 /**
@@ -15,43 +12,17 @@ interface UseWebViewActionsResult {
  * @param onModeChange - 모드 변경 콜백 함수
  * @returns WebView 액션 핸들러들
  */
-export const useBridgeActions = (
-  recipeData: RecipeData | null,
-  onModeChange?: (mode: boolean) => void,
-): UseWebViewActionsResult => {
-  const handleStartCooking = (): void => {
-    if (!recipeData) return;
-    onModeChange?.(true);
-    window.ReactNativeWebView && sendBridgeMessage(WEBVIEW_MESSAGE_TYPES.START_COOKING, recipeData);
-  };
-
-  const handleFinishCooking = (): void => {
-    if (!recipeData) return;
-    onModeChange?.(false);
-    window.ReactNativeWebView &&
-      sendBridgeMessage(WEBVIEW_MESSAGE_TYPES.FINISH_COOKING, recipeData);
-  };
-
-  const handleBackToRecipe = (): void => {
-    if (!recipeData) return;
-    onModeChange?.(false);
-    window.ReactNativeWebView &&
-      sendBridgeMessage(WEBVIEW_MESSAGE_TYPES.BACK_TO_RECIPE, recipeData);
-  };
-
-  const handleBack = (): void => {
+export const useBridgeActions = (recipeData: RecipeData | null): UseWebViewActionsResult => {
+  const handleGoHome = (): void => {
     if (!recipeData) return;
     if (window.ReactNativeWebView) {
-      sendBridgeMessage(WEBVIEW_MESSAGE_TYPES.BACK_PRESSED, recipeData);
+      sendBridgeMessage(WEBVIEW_MESSAGE_TYPES.GO_HOME, recipeData);
     } else {
       window.history.back(); // 웹 테스트용
     }
   };
 
   return {
-    handleStartCooking,
-    handleFinishCooking,
-    handleBackToRecipe,
-    handleBack,
+    handleGoHome,
   };
 };

--- a/src/bridge/types/webview.ts
+++ b/src/bridge/types/webview.ts
@@ -2,10 +2,7 @@ import { RecipeData } from '../../recipe/detail/types/recipe';
 
 // Bridge 메시지 타입들
 export type BridgeMessageType =
-  | 'START_COOKING'
-  | 'FINISH_COOKING'
-  | 'BACK_TO_RECIPE'
-  | 'BACK_PRESSED'
+  | 'GO_HOME'
   | 'REFRESH_TOKEN'
   | 'TIMER_START'
   | 'TIMER_STOP'

--- a/src/bridge/utils/webview.ts
+++ b/src/bridge/utils/webview.ts
@@ -33,35 +33,11 @@ export const sendBridgeMessage = (
 };
 
 /**
- * 조리 시작 메시지 전송
- * @param recipeData - 레시피 데이터
- */
-export const sendStartCooking = (recipeData: RecipeData): void => {
-  sendBridgeMessage(WEBVIEW_MESSAGE_TYPES.START_COOKING, recipeData);
-};
-
-/**
- * 조리 완료 메시지 전송
- * @param recipeData - 레시피 데이터
- */
-export const sendFinishCooking = (recipeData: RecipeData): void => {
-  sendBridgeMessage(WEBVIEW_MESSAGE_TYPES.FINISH_COOKING, recipeData);
-};
-
-/**
- * 레시피로 돌아가기 메시지 전송
- * @param recipeData - 레시피 데이터
- */
-export const sendBackToRecipe = (recipeData: RecipeData): void => {
-  sendBridgeMessage(WEBVIEW_MESSAGE_TYPES.BACK_TO_RECIPE, recipeData);
-};
-
-/**
  * 뒤로가기 메시지 전송
  * @param recipeData - 레시피 데이터
  */
-export const sendBackPressed = (): void => {
-  sendBridgeMessage(WEBVIEW_MESSAGE_TYPES.BACK_PRESSED, null);
+export const sendGoHome = (): void => {
+  sendBridgeMessage(WEBVIEW_MESSAGE_TYPES.GO_HOME, null);
 };
 
 /**

--- a/src/recipe/detail/RecipeDetailPage.tsx
+++ b/src/recipe/detail/RecipeDetailPage.tsx
@@ -1,5 +1,6 @@
 import { Error, Loading, useBodyScrollLock, useTransition } from '_common';
 import { useBridgeActions } from 'bridge';
+import { useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { RecipeInfo, useRecipeData } from 'recipe/detail';
 
@@ -24,6 +25,30 @@ const RecipeDetailPage = (): JSX.Element => {
   // 네이티브 앱과 통신
   const bridgeActions = useBridgeActions(recipeData);
 
+  // 네이티브 BACK_PRESSED 처리: 상세 페이지에서는 브릿지로 back 전달
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      let msg: unknown;
+      try {
+        msg = typeof event.data === 'string' ? JSON.parse(event.data) : event.data;
+      } catch (e) {
+        return;
+      }
+
+      if (
+        typeof msg === 'object' &&
+        msg !== null &&
+        'type' in msg &&
+        (msg as any).type === 'BACK_PRESSED'
+      ) {
+        bridgeActions.handleGoHome();
+      }
+    };
+
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
+  }, [bridgeActions]);
+
   // 로딩 중에는 스크롤 잠금
   useBodyScrollLock(isLoading);
 
@@ -37,7 +62,7 @@ const RecipeDetailPage = (): JSX.Element => {
         <RecipeInfo
           recipeData={recipeData}
           onStartRecipeStep={handleStartRecipeStep}
-          onBack={bridgeActions.handleBack}
+          onBack={bridgeActions.handleGoHome}
         />
       )}
     </div>

--- a/src/recipe/detail/components/RecipeInfo.tsx
+++ b/src/recipe/detail/components/RecipeInfo.tsx
@@ -1,6 +1,7 @@
 import { Header } from '_common';
-import { sendBackPressed } from 'bridge/utils/webview';
+import { sendGoHome } from 'bridge/utils/webview';
 import { useRef, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 import IngredientList from 'recipe/detail/components/IngredientList';
 import 'recipe/detail/components/IngredientList.css';
 import 'recipe/detail/components/RecipeHeader.css';
@@ -10,13 +11,13 @@ import StartCookingButton from 'recipe/detail/components/StartCookingButton';
 import 'recipe/detail/components/StartCookingButton.css';
 import Video from 'recipe/detail/components/Video';
 import { RecipeInfoProps } from 'recipe/detail/types';
-import MeasurementOverlay from 'recipe/measurement/MeasurementOverlay';
 import IngredientsModal from './IngredientsModal';
 import RecipeHeader from './RecipeHeader';
 import RecipeSteps from './RecipeSteps';
 
 const RecipeInfo = ({ recipeData, onStartRecipeStep }: RecipeInfoProps): JSX.Element => {
-  const [showMeasurement, setShowMeasurement] = useState(false);
+  const navigate = useNavigate();
+  const { id } = useParams<{ id: string }>();
   const youtubePlayerRef = useRef<YT.Player | null>(null);
 
   const { analysis } = recipeData;
@@ -31,9 +32,9 @@ const RecipeInfo = ({ recipeData, onStartRecipeStep }: RecipeInfoProps): JSX.Ele
   const [checkedCount, setCheckedCount] = useState(0);
   const [totalCount, setTotalCount] = useState(analysis.ingredients.length);
 
-  const handleBackPress = (): void => {
+  const handleGoHome = (): void => {
     if (window.ReactNativeWebView) {
-      sendBackPressed();
+      sendGoHome();
     } else {
       window.history.back();
     }
@@ -73,7 +74,7 @@ const RecipeInfo = ({ recipeData, onStartRecipeStep }: RecipeInfoProps): JSX.Ele
   return (
     <>
       <div className="recipe-info">
-        <Header title={recipeData.video_info.video_title} onBack={handleBackPress} />
+        <Header title={recipeData.video_info.video_title} onBack={handleGoHome} />
 
         <Video
           videoId={recipeData.video_info.video_id}
@@ -98,7 +99,7 @@ const RecipeInfo = ({ recipeData, onStartRecipeStep }: RecipeInfoProps): JSX.Ele
             ingredients={analysis.ingredients}
             currentServings={currentServings}
             originalServings={originalServings}
-            onOpenMeasurement={() => setShowMeasurement(true)}
+            onOpenMeasurement={() => navigate(`/recipes/${id}/measurement`)}
             onCheckedSummaryChange={(c, t) => {
               setCheckedCount(c);
               setTotalCount(t);
@@ -113,11 +114,6 @@ const RecipeInfo = ({ recipeData, onStartRecipeStep }: RecipeInfoProps): JSX.Ele
         </div>
       </div>
 
-      {showMeasurement && (
-        <div className="measurement-overlay active">
-          <MeasurementOverlay onClose={() => setShowMeasurement(false)} />
-        </div>
-      )}
       {showMissingModal && (
         <IngredientsModal
           checkedCount={checkedCount}

--- a/src/recipe/measurement/MeasurementPage.css
+++ b/src/recipe/measurement/MeasurementPage.css
@@ -1,4 +1,4 @@
-.measurement-overlay {
+.measurement-page {
   position: fixed;
   inset: 0;
   background-color: white;
@@ -11,7 +11,7 @@
   pointer-events: none;
 }
 
-.measurement-overlay.active {
+.measurement-page.active {
   opacity: 1;
   transform: translateY(0);
   pointer-events: auto;

--- a/src/recipe/measurement/MeasurementPage.tsx
+++ b/src/recipe/measurement/MeasurementPage.tsx
@@ -1,15 +1,44 @@
-import './MeasurementOverlay.css';
+import { useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import './MeasurementPage.css';
 import MeasurementSection from './components/MeasurementSection';
 
-interface Props {
-  onClose: () => void;
-}
+const MeasurementPage = () => {
+  const navigate = useNavigate();
+  const { id } = useParams<{ id: string }>();
 
-const MeasurementOverlay = ({ onClose }: Props) => {
+  const handleBack = (): void => {
+    navigate(`/recipes/${id}`, { replace: true });
+  };
+
+  // 네이티브 BACK_PRESSED 처리
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      let msg: unknown;
+      try {
+        msg = typeof event.data === 'string' ? JSON.parse(event.data) : event.data;
+      } catch (e) {
+        return;
+      }
+
+      if (
+        typeof msg === 'object' &&
+        msg !== null &&
+        'type' in msg &&
+        (msg as any).type === 'BACK_PRESSED'
+      ) {
+        navigate(`/recipes/${id}`, { replace: true });
+      }
+    };
+
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
+  }, [id, navigate]);
+
   return (
-    <div className="measurement-overlay active">
+    <div className="measurement-page active">
       <div className="overlay-content">
-        <button className="back-button" onClick={onClose}>
+        <button className="back-button" onClick={handleBack}>
           <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
             <path
               d="M15 18L9 12L15 6"
@@ -76,4 +105,4 @@ const MeasurementOverlay = ({ onClose }: Props) => {
   );
 };
 
-export default MeasurementOverlay;
+export default MeasurementPage;

--- a/src/recipe/step/RecipeStepPage.tsx
+++ b/src/recipe/step/RecipeStepPage.tsx
@@ -1,4 +1,5 @@
 import { useBodyScrollLock, useTransition } from '_common';
+import { useEffect } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import RecipeStep from 'recipe/step/components/RecipeStep';
 
@@ -26,6 +27,30 @@ const RecipeStepPage = (): JSX.Element => {
 
   // 조리 모드일 때 body 스크롤 방지
   useBodyScrollLock(true);
+
+  // 네이티브 BACK_PRESSED 처리
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      let msg: unknown;
+      try {
+        msg = typeof event.data === 'string' ? JSON.parse(event.data) : event.data;
+      } catch (e) {
+        return;
+      }
+
+      if (
+        typeof msg === 'object' &&
+        msg !== null &&
+        'type' in msg &&
+        (msg as any).type === 'BACK_PRESSED'
+      ) {
+        navigate(`/recipes/${id}`, { replace: true });
+      }
+    };
+
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
+  }, [id, navigate]);
 
   return (
     <div


### PR DESCRIPTION
- App 라우팅에 '/recipes/:id/measurement' 경로 추가
- 계량법 UI를 오버레이에서 독립 페이지로 분리
- MeasurementPage에서 뒤로가기 버튼은 navigate('/recipes/:id', { replace: true })로 동작
- 재료 화면에서 “계량법” 버튼 클릭 시 새 페이지로 이동하도록 변경
- 오버레이 렌더링 제거, navigate('/recipes/:id/measurement')로 이동
- 네이티브 BACK_PRESSED 메시지 처리 로직 추가
- RecipeStepPage: navigate('/recipes/:id', { replace: true })로 이동
- MeasurementPage: navigate('/recipes/:id', { replace: true })로 이동
- RecipeDetailPage: bridgeActions.handleBack() 호출